### PR TITLE
fix-danubetech-mapping-for-credentialsubject

### DIFF
--- a/cx-ssi-lib/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredentialSubject.java
+++ b/cx-ssi-lib/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredentialSubject.java
@@ -19,16 +19,29 @@
 
 package org.eclipse.tractusx.ssi.lib.model.verifiable.credential;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import org.eclipse.tractusx.ssi.lib.util.SerializeUtil;
 
 public class VerifiableCredentialSubject extends HashMap<String, Object> {
 
-  public VerifiableCredentialSubject() {
-    super();
-  }
+  public static final String ID = "id";
 
   public VerifiableCredentialSubject(Map<String, Object> json) {
     super(json);
+
+    try {
+      // validate getters
+      this.getId();
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+          String.format("Invalid VerifiableCredential: %s", SerializeUtil.toJson(json)), e);
+    }
+  }
+
+  public URI getId() {
+    Object id = this.get(ID);
+    return id == null ? null : SerializeUtil.asURI(id);
   }
 }

--- a/cx-ssi-lib/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jsonLd/DanubTechMapper.java
+++ b/cx-ssi-lib/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jsonLd/DanubTechMapper.java
@@ -22,9 +22,7 @@ package org.eclipse.tractusx.ssi.lib.serialization.jsonLd;
 import com.danubetech.verifiablecredentials.CredentialSubject;
 import info.weboftrust.ldsignatures.LdProof;
 import java.sql.Date;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -124,8 +122,14 @@ public class DanubTechMapper {
           "Only one credential subject is supported by the Danubetech library used.");
     }
 
-    final CredentialSubject subject =
-        CredentialSubject.builder().properties(credential.getCredentialSubject().get(0)).build();
+    final VerifiableCredentialSubject subject = credential.getCredentialSubject().get(0);
+    final HashMap<String, Object> properties = new HashMap<>(subject);
+    properties.remove("id");
+    final com.danubetech.verifiablecredentials.CredentialSubject dtSubject =
+        CredentialSubject.builder()
+            .id(credential.getCredentialSubject().get(0).getId())
+            .properties(properties)
+            .build();
 
     return com.danubetech.verifiablecredentials.VerifiableCredential.builder()
         .defaultContexts(true)
@@ -136,7 +140,7 @@ public class DanubTechMapper {
         .issuer(credential.getIssuer())
         .issuanceDate(Date.from(credential.getIssuanceDate()))
         .expirationDate(Date.from(credential.getExpirationDate()))
-        .credentialSubject(subject)
+        .credentialSubject(dtSubject)
         .ldProof(map(credential.getProof()))
         .build();
     // .credentialStatus(credential.getStatus())
@@ -152,9 +156,7 @@ public class DanubTechMapper {
   private static VerifiableCredentialSubject map(CredentialSubject dtSubject) {
     if (dtSubject == null) return null;
 
-    var subject = new VerifiableCredentialSubject();
-    subject.putAll(dtSubject.getClaims());
-    return subject;
+    return new VerifiableCredentialSubject(dtSubject.getClaims());
   }
 
   private static Proof map(LdProof dtProof) {


### PR DESCRIPTION
danubetech mapping did not work correct when the ID was an URI and only part of the subject properties. so now we set it in the setter and remove it from the properties.