### PR TITLE
chore: explain issue

### DIFF
--- a/cx-ssi-lib/src/test/java/org/eclipse/tractusx/ssi/lib/verifiable/VerifiablePresentationTest.java
+++ b/cx-ssi-lib/src/test/java/org/eclipse/tractusx/ssi/lib/verifiable/VerifiablePresentationTest.java
@@ -1,9 +1,12 @@
 package org.eclipse.tractusx.ssi.lib.verifiable;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
 import java.util.Map;
 import lombok.SneakyThrows;
+import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.presentation.VerifiablePresentation;
+import org.eclipse.tractusx.ssi.lib.serialization.jsonLd.DanubeTechMapper;
 import org.eclipse.tractusx.ssi.lib.util.TestResourceUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -22,5 +25,28 @@ public class VerifiablePresentationTest {
     Assertions.assertEquals(
         mapFromJson.get(VerifiablePresentation.VERIFIABLE_CREDENTIAL),
         vp.get(VerifiablePresentation.VERIFIABLE_CREDENTIAL));
+  }
+
+  @Test
+  public void shouldNotRemoveContext() {
+    var vpFromMap = TestResourceUtil.getBPNVerifiableCredential();
+    var vc = new VerifiableCredential(vpFromMap);
+    var vpMapped = DanubeTechMapper.map(vc);
+
+    var ctx =
+        URI.create(
+            "https://raw.githubusercontent.com/catenax-ng/product-core-schemas/main/businessPartnerData");
+
+    Assertions.assertTrue(vpMapped.getContexts().contains(ctx));
+  }
+
+  @Test
+  public void shouldLoadCachedContext() {
+    var vpFromMap = TestResourceUtil.getBPNVerifiableCredential();
+    var vc = com.danubetech.verifiablecredentials.VerifiableCredential.fromMap(vpFromMap);
+    Assertions.assertDoesNotThrow(
+        () -> {
+          vc.normalize("urdna2015");
+        });
   }
 }


### PR DESCRIPTION
Hi there when testing the the integration with MIW i did find those two issue. The issue reporting is not active yet
so i prepared a PR with those two issue. 

## The first one is `shouldNotRemoveContext` 

When mapping from `Verifialble*` to danubetech one, additional context are not forwarded.


## The second one is `shouldLoadCachedContext`

If there are custom contexts, the `normalize` will fail. As far as i got the danubetech library ship 
a document loader with some default entries in the caches. 
If the custom context is not there the normalize will fail. By default the remote loading is disable, i guess for security reason, but in case there should be a way for users like `MIW ` to add additional context in the loader cache.


