### PR TITLE
add support for multiple jsonld context

### DIFF
--- a/cx-ssi-lib/src/main/java/org/eclipse/tractusx/ssi/lib/model/JsonLdObject.java
+++ b/cx-ssi-lib/src/main/java/org/eclipse/tractusx/ssi/lib/model/JsonLdObject.java
@@ -19,10 +19,8 @@
 
 package org.eclipse.tractusx.ssi.lib.model;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.net.URI;
+import java.util.*;
 import org.eclipse.tractusx.ssi.lib.serialization.SerializeUtil;
 
 public abstract class JsonLdObject extends HashMap<String, Object> {
@@ -41,13 +39,23 @@ public abstract class JsonLdObject extends HashMap<String, Object> {
     }
   }
 
-  public List<String> getContext() {
+  public List<URI> getContext() {
     final Object context = this.get(CONTEXT);
-    if (context instanceof String) {
-      return List.of((String) context);
-    }
-    if (context instanceof List) {
-      return (List<String>) context;
+    if (context instanceof String || context instanceof URI) {
+      return List.of(SerializeUtil.asURI(context));
+    } else if (context instanceof List) {
+      final List<URI> contexts = new ArrayList<>();
+      for (Object o : (List<?>) context) {
+        if (o instanceof String || o instanceof URI) {
+          contexts.add(SerializeUtil.asURI(o));
+        } else {
+          throw new IllegalArgumentException(
+              String.format(
+                  "Context must be of type string or URI. Context Type: %s",
+                  context.getClass().getName()));
+        }
+      }
+      return contexts;
     } else {
       throw new IllegalArgumentException(
           String.format(

--- a/cx-ssi-lib/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredential.java
+++ b/cx-ssi-lib/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredential.java
@@ -49,7 +49,7 @@ import org.eclipse.tractusx.ssi.lib.serialization.SerializeUtil;
 @ToString
 public class VerifiableCredential extends JsonLdObject {
 
-  public static final String DEFAULT_CONTEXT = "https://www.w3.org/2018/credentials/v1";
+  public static final URI DEFAULT_CONTEXT = URI.create("https://www.w3.org/2018/credentials/v1");
   public static final String TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
   public static final String ID = "id";
   public static final String TYPE = "type";

--- a/cx-ssi-lib/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredentialBuilder.java
+++ b/cx-ssi-lib/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredentialBuilder.java
@@ -32,7 +32,7 @@ import org.eclipse.tractusx.ssi.lib.model.proof.Proof;
 @NoArgsConstructor
 public class VerifiableCredentialBuilder {
 
-  private List<String> context = List.of(VerifiableCredential.DEFAULT_CONTEXT);
+  private List<URI> context = List.of(VerifiableCredential.DEFAULT_CONTEXT);
   private URI id;
   private List<String> types;
   private URI issuer;
@@ -41,7 +41,7 @@ public class VerifiableCredentialBuilder {
   private List<VerifiableCredentialSubject> credentialSubject;
   private Proof proof;
 
-  public VerifiableCredentialBuilder context(List<String> context) {
+  public VerifiableCredentialBuilder context(List<URI> context) {
     this.context = context;
     return this;
   }

--- a/cx-ssi-lib/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/presentation/VerifiablePresentation.java
+++ b/cx-ssi-lib/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/presentation/VerifiablePresentation.java
@@ -32,7 +32,7 @@ import org.eclipse.tractusx.ssi.lib.serialization.SerializeUtil;
 
 @ToString
 public class VerifiablePresentation extends JsonLdObject {
-  public static final String DEFAULT_CONTEXT = "https://www.w3.org/2018/credentials/v1";
+  public static final URI DEFAULT_CONTEXT = URI.create("https://www.w3.org/2018/credentials/v1");
 
   public static final String ID = "id";
   public static final String TYPE = "type";

--- a/cx-ssi-lib/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/presentation/VerifiablePresentationBuilder.java
+++ b/cx-ssi-lib/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/presentation/VerifiablePresentationBuilder.java
@@ -28,12 +28,12 @@ import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCreden
 
 @NoArgsConstructor
 public class VerifiablePresentationBuilder {
-  private List<String> context = List.of(VerifiablePresentation.DEFAULT_CONTEXT);
+  private List<URI> context = List.of(VerifiablePresentation.DEFAULT_CONTEXT);
   private URI id;
   private List<String> types;
   private List<VerifiableCredential> verifiableCredentials;
 
-  public VerifiablePresentationBuilder context(List<String> context) {
+  public VerifiablePresentationBuilder context(List<URI> context) {
     this.context = context;
     return this;
   }

--- a/cx-ssi-lib/src/test/java/org/eclipse/tractusx/ssi/lib/verifiable/VerifiableCredentialTest.java
+++ b/cx-ssi-lib/src/test/java/org/eclipse/tractusx/ssi/lib/verifiable/VerifiableCredentialTest.java
@@ -1,9 +1,11 @@
 package org.eclipse.tractusx.ssi.lib.verifiable;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
 import java.util.Map;
 import lombok.SneakyThrows;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
+import org.eclipse.tractusx.ssi.lib.serialization.jsonLd.DanubeTechMapper;
 import org.eclipse.tractusx.ssi.lib.util.TestResourceUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -21,5 +23,26 @@ public class VerifiableCredentialTest {
     var mapFromJson = MAPPER.readValue(json, Map.class);
     Assertions.assertEquals(
         mapFromJson.get(VerifiableCredential.ISSUER), vp.get(VerifiableCredential.ISSUER));
+  }
+
+  @Test
+  public void shouldNotRemoveContext() {
+    var vcFromMap = TestResourceUtil.getAlumniVerifiableCredential();
+    var vc = new VerifiableCredential(vcFromMap);
+    var vcMapped = DanubeTechMapper.map(vc);
+
+    var ctx = URI.create("https://www.w3.org/2018/credentials/examples/v1");
+
+    Assertions.assertTrue(vcMapped.getContexts().contains(ctx));
+  }
+
+  @Test
+  public void shouldLoadCachedContext() {
+    var vcFromMap = TestResourceUtil.getAlumniVerifiableCredential();
+    var vc = com.danubetech.verifiablecredentials.VerifiableCredential.fromMap(vcFromMap);
+    Assertions.assertDoesNotThrow(
+        () -> {
+          vc.normalize("urdna2015");
+        });
   }
 }


### PR DESCRIPTION
- changed context type to URI
- danubetech mapper now functions with multiple jsonld contexts
- danubetech now loads remote contexts using https