### PR TITLE
fix vp serialzation

### DIFF
--- a/cx-ssi-lib/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredential.java
+++ b/cx-ssi-lib/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredential.java
@@ -121,7 +121,7 @@ public class VerifiableCredential extends JsonLdObject {
 
   @NonNull
   public List<String> getTypes() {
-    return (List<String>) get(TYPE);
+    return SerializeUtil.asStringList(get(TYPE));
   }
 
   @NonNull

--- a/cx-ssi-lib/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/presentation/VerifiablePresentation.java
+++ b/cx-ssi-lib/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/presentation/VerifiablePresentation.java
@@ -69,8 +69,10 @@ public class VerifiablePresentation extends JsonLdObject {
 
   @NonNull
   public List<VerifiableCredential> getVerifiableCredentials() {
+
     final List<Map<String, Object>> credentials =
-        (List<Map<String, Object>>) this.get(VERIFIABLE_CREDENTIAL);
+        SerializeUtil.asList(this.get(VERIFIABLE_CREDENTIAL));
+
     return credentials.stream().map(VerifiableCredential::new).collect(Collectors.toList());
   }
 }

--- a/cx-ssi-lib/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/SerializeUtil.java
+++ b/cx-ssi-lib/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/SerializeUtil.java
@@ -122,6 +122,12 @@ public final class SerializeUtil {
     throw new IllegalArgumentException("Unsupported type: " + object.getClass());
   }
 
+  public static List asList(Object object) {
+    if (object instanceof List) {
+      return (List) object;
+    } else return List.of(object);
+  }
+
   private static Map<String, Object> getLinkedHashMap(Map<String, Object> map) {
     // convert Map to LinkedHashMap to preserve property order
     Class<? extends Map> aClass = map.getClass();

--- a/cx-ssi-lib/src/test/java/org/eclipse/tractusx/ssi/lib/verifiable/VerifiablePresentationTest.java
+++ b/cx-ssi-lib/src/test/java/org/eclipse/tractusx/ssi/lib/verifiable/VerifiablePresentationTest.java
@@ -23,4 +23,15 @@ public class VerifiablePresentationTest {
         mapFromJson.get(VerifiablePresentation.VERIFIABLE_CREDENTIAL),
         vp.get(VerifiablePresentation.VERIFIABLE_CREDENTIAL));
   }
+
+  @Test
+  @SneakyThrows
+  public void canSerializeVPwithCredentialNotAsList() {
+    final Map<String, Object> vpFromMap = TestResourceUtil.getAlumniVerifiablePresentation();
+    var vp = new VerifiablePresentation(vpFromMap);
+    vp.put("verifiableCredential", vp.getVerifiableCredentials().get(0));
+    var json = vp.toJson();
+    var mapFromJson = MAPPER.readValue(json, Map.class);
+    Assertions.assertDoesNotThrow(() -> new VerifiablePresentation(mapFromJson));
+  }
 }


### PR DESCRIPTION
When a Verifiable Presentation contains a single Verifiable Credential the de-serialization fails. This PR fixes it.